### PR TITLE
Revert "Add instructions for installation on Windows"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,3 @@ registry path.
 If on MAC please provide the games bundle_id which can be found by calling
 
 ```/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -dump | grep {game_name}```
-
-## Installation
-
-### Windows
-Extract to `%LOCALAPPDATA%\GOG.com\Galaxy\plugins\installed\battlenet`
-
-### macOS
-Extract to `~/Library/Application Support/GOG.com/Galaxy/plugins/installed`


### PR DESCRIPTION
Reverts FriendsOfGalaxy/galaxy-integration-battlenet#14
because meanwhile README Install section was already updated:
 https://github.com/FriendsOfGalaxy/galaxy-integration-battlenet/commit/8c294a72cd875db2998464fe9db110c38d54e068